### PR TITLE
Nieuws widget (werkt nog niet soepel)

### DIFF
--- a/DB.php
+++ b/DB.php
@@ -36,7 +36,7 @@ class DB
     public $host = "localhost";
     public $databaseName = "afterpay";
     public $username = "root";
-    public $password = "klapot";
+    public $password = "";
 
     /**
      * @return string

--- a/pages/test123.txt
+++ b/pages/test123.txt
@@ -1,0 +1,1 @@
+O:4:"Page":8:{s:16:"defaultTwoLayout";s:8:"vertical";s:18:"defaultThreeLayout";s:3:"1-2";s:8:"pageName";s:7:"test123";s:7:"visible";s:4:"true";s:6:"amount";i:4;s:7:"widgets";a:4:{i:0;s:6:"nieuws";i:1;s:10:"weathermap";i:2;s:5:"empty";i:3;s:5:"empty";}s:9:"twoLayout";s:8:"vertical";s:11:"threeLayout";s:3:"1-2";}

--- a/widgets/nieuws/Nieuws.php
+++ b/widgets/nieuws/Nieuws.php
@@ -1,0 +1,33 @@
+<?php
+
+?>
+<html> 
+<head>
+<!-- idk of dit werkt -->
+<script>
+ $(document).ready(function()
+ {
+ setInterval(function() {
+     .news 
+
+ },5000);
+ });
+
+</script>
+<!-- dit is het nu.nl algemeen rss nieuws omgezet via een site naar html -->
+</head>
+<div class="news" >
+<script src="//rss.bloople.net/?url=https%3A%2F%2Fwww.nu.nl%2Frss%2FAlgemeen&detail=30&limit=4&showtitle=true&type=js"></script>
+</div>
+<style>
+/* gewoon geprobeerd te kijken wat er nou verneukt werd, want alleen de tekst wordt verplaats. de achtergrond blijft wel goed. */
+.news {
+    max-height: 95%;
+    padding: 35px;
+    height: 99%;
+    width: 99%;
+    background-color: lightblue;
+    overflow: hidden;
+}
+</style> 
+

--- a/widgets/text/test123/4.txt
+++ b/widgets/text/test123/4.txt
@@ -1,0 +1,1 @@
+<p>Bedankt voor de airpressure die heb ik altijd al willen weten</p><p><br></p>


### PR DESCRIPTION
Kijk het probleem nu is dat de tekst verplaatst als je andere widgets toevoegd, de achtergrond. DIe heb ik ook een kleurtje gegeven blijft op dezelfde plek staan. Je kan ook de widget zelf in de link veranderen, 30 is limiet van woorden per kopje. 4 staat voor hoeveel verschillende titels er kunnen zijn (met 3 ziet het er het mooist uit) en showtitle laat nu.nl algemeen zien.